### PR TITLE
Fix key generating function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [0.5.1]
+
+- Update to dio 5.3.3
+- Update dependency constraints to sdk: '>=2.18.0 <4.0.0'
+- Fix an issue with key generating method
+
 # [0.5.0]
 
 - Update to dio 5.0.0

--- a/lib/src/firebase_performance_dio.dart
+++ b/lib/src/firebase_performance_dio.dart
@@ -32,7 +32,7 @@ class DioFirebasePerformanceInterceptor extends Interceptor {
         options.method.asHttpMethod()!,
       );
 
-      final requestKey = options.extra.hashCode;
+      final requestKey = options.extra.toString().hashCode;
       _map[requestKey] = metric;
       final requestContentLength = requestContentLengthMethod(options);
       await metric.start();
@@ -47,7 +47,7 @@ class DioFirebasePerformanceInterceptor extends Interceptor {
   Future onResponse(
       Response response, ResponseInterceptorHandler handler) async {
     try {
-      final requestKey = response.requestOptions.extra.hashCode;
+      final requestKey = response.requestOptions.extra.toString().hashCode;
       final metric = _map[requestKey];
       metric?.setResponse(response, responseContentLengthMethod);
       await metric?.stop();
@@ -59,7 +59,7 @@ class DioFirebasePerformanceInterceptor extends Interceptor {
   @override
   Future onError(DioError err, ErrorInterceptorHandler handler) async {
     try {
-      final requestKey = err.requestOptions.extra.hashCode;
+      final requestKey = err.requestOptions.extra.toString().hashCode;
       final metric = _map[requestKey];
       metric?.setResponse(err.response, responseContentLengthMethod);
       await metric?.stop();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^5.3.3
+  dio: ^5.0.0
   firebase_performance: ">=0.8.0 <0.10.0"
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: firebase_performance_dio
 description: Dio Firebase performance monitoring.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/darkxanter/firebase_performance_dio
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^5.0.0
+  dio: ^5.3.3
   firebase_performance: ">=0.8.0 <0.10.0"
 
 dev_dependencies:


### PR DESCRIPTION
Calling "hashCode" on a Map, returns different output (requestKey) with equal entry (requestOptions.extra). That couses no data to be sent to  FirebasePerformance console, since no one process gets completed. 
Replasing
 " requestKey = options.extra.hashCode; " 
with
" requestKey = options.extra.toString().hashCode; "
in all three places, fixed the issue and the application started send data to the console.